### PR TITLE
getPairingLink now generates a valid URL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ export default class {
    * const link = chatInstance.getPairingLink();
    */
   getPairingLink() {
-    return this.#invite;
+    return `${this.#invite}#0000`;
   }
 
   /**


### PR DESCRIPTION
Previously the returned URL lacked a pairing code resulting in the wallet showing an error upon opening